### PR TITLE
Fix for doors angles + UI

### DIFF
--- a/cwxml/ymap.py
+++ b/cwxml/ymap.py
@@ -271,7 +271,8 @@ class ExtensionDoor(Extension):
         self.enable_limit_angle = ValueProperty("enableLimitAngle", False)
         self.starts_locked = ValueProperty("startsLocked", False)
         self.can_break = ValueProperty("canBreak", False)
-        self.limit_angle = ValueProperty("limitAngle", False)
+        self.limit_angle_pull = ValueProperty("nbjubyaa_0xcfe37bdb", False)
+        self.limit_angle_push = ValueProperty("gfkrydta_0xa0cf3c8d", False)
         self.door_target_ratio = ValueProperty("doorTargetRatio")
         self.audio_hash = TextProperty("audioHash")
 

--- a/ytyp/properties/extensions.py
+++ b/ytyp/properties/extensions.py
@@ -256,7 +256,8 @@ class DoorExtensionProperties(BaseExtensionProperties, PropertyGroup):
     enable_limit_angle: BoolProperty(name="Enable Limit Angle")
     starts_locked: BoolProperty(name="Starts Locked")
     can_break: BoolProperty(name="Can Break")
-    limit_angle: FloatProperty(name="Limit Angle")
+    limit_angle_pull: FloatProperty(name="Limit Angle pull")
+    limit_angle_push: FloatProperty(name="Limit Angle push")
     door_target_ratio: FloatProperty(name="Door Target Ratio", min=0)
     audio_hash: StringProperty(name="Audio Hash")
 


### PR DESCRIPTION
I fix the doors angles UI and fonction to match RDR3 angles (compare to GTA, RDR3 use two angles on doors) , i put natives hash too so CodeX on will be able to correctly read them when we import a YTYP.